### PR TITLE
Bump runtime to 3.34

### DIFF
--- a/appdata_screenshot.patch
+++ b/appdata_screenshot.patch
@@ -1,0 +1,11 @@
+--- a/data/org.caione.GScope.appdata.xml.in	2020-01-26 12:26:07.511004710 +0100
++++ b/data/org.caione.GScope.appdata.xml.in	2020-01-26 12:27:31.757169309 +0100
+@@ -17,7 +17,7 @@
+   </description>
+   <screenshots>
+     <screenshot type="default">
+-      <image>https://gitlab.gnome.org/carlo.caione/gscope/tree/master/data/screenshot.png</image>
++      <image>https://gitlab.gnome.org/carlo.caione/gscope/raw/master/data/screenshot.png</image>
+     </screenshot>
+   </screenshots>
+   <launchable type="desktop-id">org.caione.GScope.desktop</launchable>

--- a/org.caione.GScope.json
+++ b/org.caione.GScope.json
@@ -55,6 +55,10 @@
                     "type": "git",
                     "tag": "v0.1.1",
                     "url": "https://gitlab.gnome.org/carlo.caione/gscope.git"
+                },
+                {
+                    "type": "patch",
+                    "path": "appdata_screenshot.patch"
                 }
             ]
         }

--- a/org.caione.GScope.json
+++ b/org.caione.GScope.json
@@ -1,18 +1,14 @@
 {
     "app-id": "org.caione.GScope",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.30",
+    "runtime-version": "3.34",
     "sdk": "org.gnome.Sdk",
     "command": "gscope",
     "finish-args": [
         "--share=ipc",
         "--socket=x11",
         "--socket=wayland",
-        "--filesystem=xdg-run/dconf",
-        "--filesystem=~/.config/dconf:ro",
-        "--filesystem=host",
-        "--talk-name=ca.desrt.dconf",
-        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+        "--filesystem=host"
     ],
     "cleanup": [
         "/include",
@@ -31,9 +27,9 @@
             "config-opts" : [ "--disable-Werror", "--disable-doc" ],
             "sources" : [
                 {
-                    "type" : "git",
-                    "tag": "3.24.9",
-                    "url" : "https://gitlab.gnome.org/GNOME/gtksourceview.git"
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/gtksourceview/3.24/gtksourceview-3.24.11.tar.xz",
+                    "sha256": "691b074a37b2a307f7f48edc5b8c7afa7301709be56378ccf9cc9735909077fd"
                 }
             ]
         },


### PR DESCRIPTION
Settings migration post dconf removal isn't needed. See https://gitlab.gnome.org/carlo.caione/gscope/blob/master/data/org.caione.GScope.gschema.xml

Closes #2 
Fixes #1 