### PR TITLE
Use Freedesktop 25.08 instead of GNOME 46 

### DIFF
--- a/fix-gtksourceview.patch
+++ b/fix-gtksourceview.patch
@@ -1,0 +1,42 @@
+From 8e6c8102d9a9080c31b2ce0731317a2bb946d236 Mon Sep 17 00:00:00 2001
+From: Will Thompson <wjt@endlessos.org>
+Date: Mon, 24 Mar 2025 10:22:03 +0000
+Subject: [PATCH] gtksourceview: Add typecast when setting source_buffer
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With the GNOME 48 runtime, build fails with:
+
+    gtksourceview.c: In function ‘set_source_buffer’:
+    gtksourceview.c:1589:43: error: assignment to ‘GtkSourceBuffer *’ {aka ‘struct _GtkSourceBuffer *’} from incompatible pointer type ‘GtkTextBuffer *’ {aka ‘struct _GtkTextBuffer *’} [-Wincompatible-pointer-types]
+     1589 |                 view->priv->source_buffer = g_object_ref (buffer);
+          |                                           ^
+
+I believe this is due to newer GLib versions preserving type information
+in g_object_ref(). This code path is guarded with a GTK_IS_SOURCE_BUFFER
+(buffer) check so the assignment is correct. Add a cast.
+
+(On newer branches, this was fixed in commit
+aa3140aa69760b62e4aaea726801951c1cb6b8b5 but that does not apply cleanly
+to the gnome-3-24 branch.)
+---
+ gtksourceview/gtksourceview.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gtksourceview/gtksourceview.c b/gtksourceview/gtksourceview.c
+index 0c3a007b..c8be4bfd 100644
+--- a/gtksourceview/gtksourceview.c
++++ b/gtksourceview/gtksourceview.c
+@@ -1586,7 +1586,7 @@ set_source_buffer (GtkSourceView *view,
+ 	{
+ 		GtkSourceBufferInternal *buffer_internal;
+ 
+-		view->priv->source_buffer = g_object_ref (buffer);
++		view->priv->source_buffer = g_object_ref (GTK_SOURCE_BUFFER (buffer));
+ 
+ 		g_signal_connect (buffer,
+ 				  "highlight-updated",
+-- 
+2.39.5
+

--- a/org.caione.GScope.json
+++ b/org.caione.GScope.json
@@ -1,8 +1,8 @@
 {
     "app-id": "org.caione.GScope",
-    "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
-    "sdk": "org.gnome.Sdk",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "25.08",
+    "sdk": "org.freedesktop.Sdk",
     "command": "gscope",
     "finish-args": [
         "--device=dri",

--- a/org.caione.GScope.json
+++ b/org.caione.GScope.json
@@ -24,15 +24,19 @@
     ],
     "modules": [
         {
-            "name" : "gtksourceview",
-            "config-opts" : [ "--disable-Werror", "--disable-doc" ],
-            "sources" : [
-                {
-                    "type" : "archive",
-                    "url" : "https://download.gnome.org/sources/gtksourceview/3.24/gtksourceview-3.24.11.tar.xz",
-                    "sha256": "691b074a37b2a307f7f48edc5b8c7afa7301709be56378ccf9cc9735909077fd"
-                }
-            ]
+            "name": "gtksourceview",
+            "config-opts": [
+                "--disable-Werror",
+                "--enable-gtk-doc=no"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "https://download.gnome.org/sources/gtksourceview/3.24/gtksourceview-3.24.11.tar.xz",
+                "sha256": "691b074a37b2a307f7f48edc5b8c7afa7301709be56378ccf9cc9735909077fd"
+            },{
+                "type": "patch",
+                "path": "fix-gtksourceview.patch"
+            }]
         },
         {
             "name": "cscope",


### PR DESCRIPTION
Freedesktop runtimes usually supported longer then GNOME runtimes.

For example: Runtime 25.08 will be supported until 2027/09.

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/wikis/Releases

Also patch gtksouceview-3 to fix build.